### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,11 +37,11 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "dylo"
-version = "1.0.0"
+version = "1.0.1"
 
 [[package]]
 name = "dylo-cli"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "camino",
  "fs-err",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "dylo-runtime"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "rubicon",
 ]

--- a/dylo-cli/Cargo.toml
+++ b/dylo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dylo-cli"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Generate dyn-compatible traits with proc macros"

--- a/dylo-runtime/CHANGELOG.md
+++ b/dylo-runtime/CHANGELOG.md
@@ -7,19 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.2](https://github.com/bearcove/dylo/compare/dylo-cli-v1.0.1...dylo-cli-v1.0.2) - 2024-12-05
+## [1.0.1](https://github.com/bearcove/dylo/compare/dylo-runtime-v1.0.0...dylo-runtime-v1.0.1) - 2024-12-05
 
 ### Other
 
-- Avoid 'dylo runtime is unused' warnings
+- Compat check
 - Yeah ok we need to expose rubicon features through dylo-runtime, a non-proc-macro crate
+- Change CON_ to DYLO_
 - Don't be so chatty
 - Default to finding everything, not necessarily under a mods/ folder
-- Suffix include! items
-- Add dylo-runtime, keep optional deps if they're enabled by other features
-
-## [1.0.1](https://github.com/bearcove/dylo/compare/dylo-cli-v1.0.0...dylo-cli-v1.0.1) - 2024-12-05
-
-### Other
-
-- Remove cfg_attr(feature = 'impl', etc.) attributes

--- a/dylo-runtime/Cargo.toml
+++ b/dylo-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dylo-runtime"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Dynamic library loader for con traits"

--- a/dylo/CHANGELOG.md
+++ b/dylo/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.1](https://github.com/bearcove/dylo/compare/dylo-v1.0.0...dylo-v1.0.1) - 2024-12-05
+
+### Other
+
+- Yeah ok we need to expose rubicon features through dylo-runtime, a non-proc-macro crate
+- Don't be so chatty

--- a/dylo/Cargo.toml
+++ b/dylo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dylo"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Generate dyn-compatible traits with procedural macros"


### PR DESCRIPTION
## 🤖 New release
* `dylo`: 1.0.0 -> 1.0.1
* `dylo-cli`: 1.0.1 -> 1.0.2
* `dylo-runtime`: 1.0.0 -> 1.0.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `dylo`
<blockquote>

## [1.0.1](https://github.com/bearcove/dylo/compare/dylo-v1.0.0...dylo-v1.0.1) - 2024-12-05

### Other

- Yeah ok we need to expose rubicon features through dylo-runtime, a non-proc-macro crate
- Don't be so chatty
</blockquote>

## `dylo-cli`
<blockquote>

## [1.0.2](https://github.com/bearcove/dylo/compare/dylo-cli-v1.0.1...dylo-cli-v1.0.2) - 2024-12-05

### Other

- Avoid 'dylo runtime is unused' warnings
- Yeah ok we need to expose rubicon features through dylo-runtime, a non-proc-macro crate
- Don't be so chatty
- Default to finding everything, not necessarily under a mods/ folder
- Suffix include! items
- Add dylo-runtime, keep optional deps if they're enabled by other features
</blockquote>

## `dylo-runtime`
<blockquote>

## [1.0.1](https://github.com/bearcove/dylo/compare/dylo-runtime-v1.0.0...dylo-runtime-v1.0.1) - 2024-12-05

### Other

- Compat check
- Yeah ok we need to expose rubicon features through dylo-runtime, a non-proc-macro crate
- Change CON_ to DYLO_
- Don't be so chatty
- Default to finding everything, not necessarily under a mods/ folder
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).