### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ version = "1.0.1"
 
 [[package]]
 name = "dylo-cli"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "camino",
  "fs-err",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "dylo-runtime"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "rubicon",
 ]

--- a/dylo-cli/CHANGELOG.md
+++ b/dylo-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3](https://github.com/bearcove/dylo/compare/dylo-cli-v1.0.2...dylo-cli-v1.0.3) - 2024-12-06
+
+### Other
+
+- I suspect the presence of slashes gave us linker errors...
+
 ## [1.0.2](https://github.com/bearcove/dylo/compare/dylo-cli-v1.0.1...dylo-cli-v1.0.2) - 2024-12-05
 
 ### Other

--- a/dylo-cli/Cargo.toml
+++ b/dylo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dylo-cli"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Generate dyn-compatible traits with proc macros"

--- a/dylo-runtime/CHANGELOG.md
+++ b/dylo-runtime/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2](https://github.com/bearcove/dylo/compare/dylo-runtime-v1.0.1...dylo-runtime-v1.0.2) - 2024-12-06
+
+### Other
+
+- I suspect the presence of slashes gave us linker errors...
+
 ## [1.0.1](https://github.com/bearcove/dylo/compare/dylo-runtime-v1.0.0...dylo-runtime-v1.0.1) - 2024-12-05
 
 ### Other

--- a/dylo-runtime/Cargo.toml
+++ b/dylo-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dylo-runtime"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Dynamic library loader for con traits"


### PR DESCRIPTION
## 🤖 New release
* `dylo-cli`: 1.0.2 -> 1.0.3
* `dylo-runtime`: 1.0.1 -> 1.0.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `dylo-cli`
<blockquote>

## [1.0.3](https://github.com/bearcove/dylo/compare/dylo-cli-v1.0.2...dylo-cli-v1.0.3) - 2024-12-06

### Other

- I suspect the presence of slashes gave us linker errors...
</blockquote>

## `dylo-runtime`
<blockquote>

## [1.0.2](https://github.com/bearcove/dylo/compare/dylo-runtime-v1.0.1...dylo-runtime-v1.0.2) - 2024-12-06

### Other

- I suspect the presence of slashes gave us linker errors...
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).