### PR TITLE
chore: release v1.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.0.1"
 
 [[package]]
 name = "dylo-cli"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "camino",
  "fs-err",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "dylo-runtime"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "rubicon",
 ]

--- a/dylo-cli/CHANGELOG.md
+++ b/dylo-cli/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4](https://github.com/bearcove/dylo/compare/dylo-cli-v1.0.3...dylo-cli-v1.0.4) - 2024-12-06
+
+### Other
+
+- Use prettyplease rather than rustfmt
+- Remove cfg(not(feature = "impl")) attributes
+
 ## [1.0.3](https://github.com/bearcove/dylo/compare/dylo-cli-v1.0.2...dylo-cli-v1.0.3) - 2024-12-06
 
 ### Other

--- a/dylo-cli/Cargo.toml
+++ b/dylo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dylo-cli"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Generate dyn-compatible traits with proc macros"

--- a/dylo-runtime/CHANGELOG.md
+++ b/dylo-runtime/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4](https://github.com/bearcove/dylo/compare/dylo-runtime-v1.0.3...dylo-runtime-v1.0.4) - 2024-12-06
+
+### Other
+
+- Remove cfg(not(feature = "impl")) attributes
+
 ## [1.0.3](https://github.com/bearcove/dylo/compare/dylo-runtime-v1.0.2...dylo-runtime-v1.0.3) - 2024-12-06
 
 ### Other

--- a/dylo-runtime/Cargo.toml
+++ b/dylo-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dylo-runtime"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Dynamic library loader for con traits"


### PR DESCRIPTION
## 🤖 New release
* `dylo-cli`: 1.0.3 -> 1.0.4
* `dylo-runtime`: 1.0.3 -> 1.0.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `dylo-cli`
<blockquote>

## [1.0.4](https://github.com/bearcove/dylo/compare/dylo-cli-v1.0.3...dylo-cli-v1.0.4) - 2024-12-06

### Other

- Use prettyplease rather than rustfmt
- Remove cfg(not(feature = "impl")) attributes
</blockquote>

## `dylo-runtime`
<blockquote>

## [1.0.4](https://github.com/bearcove/dylo/compare/dylo-runtime-v1.0.3...dylo-runtime-v1.0.4) - 2024-12-06

### Other

- Remove cfg(not(feature = "impl")) attributes
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).