### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,11 +34,11 @@ dependencies = [
 
 [[package]]
 name = "dylo"
-version = "1.0.1"
+version = "1.0.2"
 
 [[package]]
 name = "dylo-cli"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "camino",
  "fs-err",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "dylo-runtime"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "rubicon",
 ]

--- a/dylo-cli/CHANGELOG.md
+++ b/dylo-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.5](https://github.com/bearcove/dylo/compare/dylo-cli-v1.0.4...dylo-cli-v1.0.5) - 2025-02-22
+
+### Other
+
+- rust 1.85 / edition 2024
+
 ## [1.0.4](https://github.com/bearcove/dylo/compare/dylo-cli-v1.0.3...dylo-cli-v1.0.4) - 2024-12-06
 
 ### Other

--- a/dylo-cli/Cargo.toml
+++ b/dylo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dylo-cli"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2024"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Generate dyn-compatible traits with proc macros"

--- a/dylo-runtime/CHANGELOG.md
+++ b/dylo-runtime/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.5](https://github.com/bearcove/dylo/compare/dylo-runtime-v1.0.4...dylo-runtime-v1.0.5) - 2025-02-22
+
+### Other
+
+- rust 1.85 / edition 2024
+
 ## [1.0.4](https://github.com/bearcove/dylo/compare/dylo-runtime-v1.0.3...dylo-runtime-v1.0.4) - 2024-12-06
 
 ### Other

--- a/dylo-runtime/Cargo.toml
+++ b/dylo-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dylo-runtime"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2024"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Dynamic library loader for con traits"

--- a/dylo/CHANGELOG.md
+++ b/dylo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2](https://github.com/bearcove/dylo/compare/dylo-v1.0.1...dylo-v1.0.2) - 2025-02-22
+
+### Other
+
+- rust 1.85 / edition 2024
+
 ## [1.0.1](https://github.com/bearcove/dylo/compare/dylo-v1.0.0...dylo-v1.0.1) - 2024-12-05
 
 ### Other

--- a/dylo/Cargo.toml
+++ b/dylo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dylo"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2024"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Generate dyn-compatible traits with procedural macros"


### PR DESCRIPTION



## 🤖 New release

* `dylo`: 1.0.1 -> 1.0.2
* `dylo-cli`: 1.0.4 -> 1.0.5
* `dylo-runtime`: 1.0.4 -> 1.0.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `dylo`

<blockquote>

## [1.0.2](https://github.com/bearcove/dylo/compare/dylo-v1.0.1...dylo-v1.0.2) - 2025-02-22

### Other

- rust 1.85 / edition 2024
</blockquote>

## `dylo-cli`

<blockquote>

## [1.0.5](https://github.com/bearcove/dylo/compare/dylo-cli-v1.0.4...dylo-cli-v1.0.5) - 2025-02-22

### Other

- rust 1.85 / edition 2024
</blockquote>

## `dylo-runtime`

<blockquote>

## [1.0.5](https://github.com/bearcove/dylo/compare/dylo-runtime-v1.0.4...dylo-runtime-v1.0.5) - 2025-02-22

### Other

- rust 1.85 / edition 2024
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).