### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.0.2"
 
 [[package]]
 name = "dylo-cli"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "camino",
  "fs-err",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "dylo-runtime"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "rubicon",
 ]

--- a/dylo-cli/CHANGELOG.md
+++ b/dylo-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.7](https://github.com/bearcove/dylo/compare/dylo-cli-v1.0.6...dylo-cli-v1.0.7) - 2025-03-01
+
+### Other
+
+- Only print updates if changes were made
+
 ## [1.0.6](https://github.com/bearcove/dylo/compare/dylo-cli-v1.0.5...dylo-cli-v1.0.6) - 2025-02-28
 
 ### Other

--- a/dylo-cli/Cargo.toml
+++ b/dylo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dylo-cli"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2024"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Generate dyn-compatible traits with proc macros"

--- a/dylo-runtime/CHANGELOG.md
+++ b/dylo-runtime/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.6](https://github.com/bearcove/dylo/compare/dylo-runtime-v1.0.5...dylo-runtime-v1.0.6) - 2025-03-01
+
+### Other
+
+- Make dylo quieter by default
+
 ## [1.0.5](https://github.com/bearcove/dylo/compare/dylo-runtime-v1.0.4...dylo-runtime-v1.0.5) - 2025-02-22
 
 ### Other

--- a/dylo-runtime/Cargo.toml
+++ b/dylo-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dylo-runtime"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2024"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Dynamic library loader for con traits"


### PR DESCRIPTION



## 🤖 New release

* `dylo-cli`: 1.0.6 -> 1.0.7
* `dylo-runtime`: 1.0.5 -> 1.0.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `dylo-cli`

<blockquote>

## [1.0.7](https://github.com/bearcove/dylo/compare/dylo-cli-v1.0.6...dylo-cli-v1.0.7) - 2025-03-01

### Other

- Only print updates if changes were made
</blockquote>

## `dylo-runtime`

<blockquote>

## [1.0.6](https://github.com/bearcove/dylo/compare/dylo-runtime-v1.0.5...dylo-runtime-v1.0.6) - 2025-03-01

### Other

- Make dylo quieter by default
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).