### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,11 +123,11 @@ dependencies = [
 
 [[package]]
 name = "dylo"
-version = "1.0.2"
+version = "1.0.3"
 
 [[package]]
 name = "dylo-cli"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "camino",
  "clap",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "dylo-runtime"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "rubicon",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ version = "1.0.3"
 
 [[package]]
 name = "dylo-cli"
-version = "3.0.2"
+version = "4.0.0"
 dependencies = [
  "camino",
  "clap",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "dylo-runtime"
-version = "1.0.7"
+version = "2.0.0"
 dependencies = [
  "rubicon",
 ]

--- a/dylo-cli/CHANGELOG.md
+++ b/dylo-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.2](https://github.com/bearcove/dylo/compare/dylo-cli-v3.0.1...dylo-cli-v3.0.2) - 2025-03-22
+
+### Added
+
+- [**breaking**] Disable dylo's building functionality, have it look in `../lib`
+
 ## [3.0.1](https://github.com/bearcove/dylo/compare/dylo-cli-v3.0.0...dylo-cli-v3.0.1) - 2025-03-21
 
 ### Other

--- a/dylo-cli/CHANGELOG.md
+++ b/dylo-cli/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.0.2](https://github.com/bearcove/dylo/compare/dylo-cli-v3.0.1...dylo-cli-v3.0.2) - 2025-03-22
+## [4.0.0](https://github.com/bearcove/dylo/compare/dylo-cli-v3.0.1...dylo-cli-v4.0.0) - 2025-03-22
 
 ### Added
 

--- a/dylo-cli/Cargo.toml
+++ b/dylo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dylo-cli"
-version = "3.0.1"
+version = "3.0.2"
 edition = "2024"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Generate dyn-compatible traits with proc macros"

--- a/dylo-cli/Cargo.toml
+++ b/dylo-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dylo-cli"
-version = "3.0.2"
+version = "4.0.0"
 edition = "2024"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Generate dyn-compatible traits with proc macros"

--- a/dylo-runtime/CHANGELOG.md
+++ b/dylo-runtime/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.7](https://github.com/bearcove/dylo/compare/dylo-runtime-v1.0.6...dylo-runtime-v1.0.7) - 2025-03-22
+## [2.0.0](https://github.com/bearcove/dylo/compare/dylo-runtime-v1.0.6...dylo-runtime-v2.0.0) - 2025-03-22
 
 ### Added
 

--- a/dylo-runtime/CHANGELOG.md
+++ b/dylo-runtime/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.7](https://github.com/bearcove/dylo/compare/dylo-runtime-v1.0.6...dylo-runtime-v1.0.7) - 2025-03-22
+
+### Added
+
+- [**breaking**] Disable dylo's building functionality, have it look in `../lib`
+
 ## [1.0.6](https://github.com/bearcove/dylo/compare/dylo-runtime-v1.0.5...dylo-runtime-v1.0.6) - 2025-03-01
 
 ### Other

--- a/dylo-runtime/Cargo.toml
+++ b/dylo-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dylo-runtime"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2024"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Dynamic library loader for con traits"

--- a/dylo-runtime/Cargo.toml
+++ b/dylo-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dylo-runtime"
-version = "1.0.7"
+version = "2.0.0"
 edition = "2024"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Dynamic library loader for con traits"

--- a/dylo/CHANGELOG.md
+++ b/dylo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3](https://github.com/bearcove/dylo/compare/dylo-v1.0.2...dylo-v1.0.3) - 2025-03-22
+
+### Added
+
+- [**breaking**] Disable dylo's building functionality, have it look in `../lib`
+
 ## [1.0.2](https://github.com/bearcove/dylo/compare/dylo-v1.0.1...dylo-v1.0.2) - 2025-02-22
 
 ### Other

--- a/dylo/Cargo.toml
+++ b/dylo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dylo"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2024"
 authors = ["Amos Wenger <amos@bearcove.net>"]
 description = "Generate dyn-compatible traits with procedural macros"


### PR DESCRIPTION



## 🤖 New release

* `dylo`: 1.0.2 -> 1.0.3
* `dylo-cli`: 3.0.1 -> 3.0.2
* `dylo-runtime`: 1.0.6 -> 1.0.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `dylo`

<blockquote>

## [1.0.3](https://github.com/bearcove/dylo/compare/dylo-v1.0.2...dylo-v1.0.3) - 2025-03-22

### Added

- [**breaking**] Disable dylo's building functionality, have it look in `../lib`
</blockquote>

## `dylo-cli`

<blockquote>

## [3.0.2](https://github.com/bearcove/dylo/compare/dylo-cli-v3.0.1...dylo-cli-v3.0.2) - 2025-03-22

### Added

- [**breaking**] Disable dylo's building functionality, have it look in `../lib`
</blockquote>

## `dylo-runtime`

<blockquote>

## [1.0.7](https://github.com/bearcove/dylo/compare/dylo-runtime-v1.0.6...dylo-runtime-v1.0.7) - 2025-03-22

### Added

- [**breaking**] Disable dylo's building functionality, have it look in `../lib`
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).